### PR TITLE
Fixup .m3u (and NEC optical disc) support in es_systems.cfg

### DIFF
--- a/12252020/es_systems.cfg
+++ b/12252020/es_systems.cfg
@@ -1,0 +1,1139 @@
+<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
+<systemList xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance">
+	<system>
+		<name>amiga</name>
+		<fullname>Amiga</fullname>
+		<path>/roms/amiga</path>
+		<extension>.lha .LHA .adf .ADF .m3u .M3U</extension>
+		<command>sudo perfmax; /usr/local/bin/amiga.sh %EMULATOR% %CORE% %ROM%; sudo perfnorm</command>
+		   <emulators>
+		      <emulator name="standalone">
+		      </emulator>
+		      <emulator name="retroarch">
+		 	<cores>
+		 	  <core>puae</core>
+		 	</cores>			 
+		      </emulator>			  
+		   </emulators>
+		<platform>amiga</platform>
+		<theme>amiga</theme>
+	</system>
+	<system>
+	<name>amigacd32</name>
+		<fullname>Commodore - Amiga CD32</fullname>
+		<path>/roms/amigacd32/</path>
+		<extension>.cue .CUE .ccd .CCD .nrg .NRG .mds .MDS .iso .ISO .m3u .M3U</extension>
+		<command>sudo perfmax; /usr/local/bin/retroarch -L /home/ark/.config/retroarch/cores/puae_libretro.so %ROM%; sudo perfnorm</command>
+		<platform>amigacd32</platform>
+		<theme>amigacd32</theme>
+	</system>
+	<system>
+		<name>amstradcpc</name>
+		<fullname>Amstrad CPC</fullname>
+		<path>/roms/amstradcpc</path>
+		<extension>.cpc .CPC .dsk .DSK</extension>
+		<command>sudo perfmax; /usr/local/bin/retroarch -L /home/ark/.config/retroarch/cores/cap32_libretro.so %ROM%; sudo perfnorm</command>
+		<platform>amstradcpc</platform>
+		<theme>amstradcpc</theme>
+	</system>
+	<system>
+		<name>arcade</name>
+		<fullname>Arcade - Various Platform</fullname>
+		<path>/roms/arcade/</path>
+		<extension>.zip .ZIP .7z .7Z .cue .CUE</extension>
+		<command>sudo perfmax; /usr/local/bin/%EMULATOR% -L /home/ark/.config/%EMULATOR%/cores/%CORE%_libretro.so %ROM%; sudo perfnorm</command>
+		   <emulators>
+		      <emulator name="retroarch">
+		 	<cores>
+		 	  <core>fbneo</core>
+		 	  <core>fbalpha2012</core>
+		 	</cores>
+		      </emulator>
+		      <emulator name="retroarch32">
+		 	<cores>
+		 	  <core>fbalpha2016</core>
+		 	  <core>fbalpha2018</core>
+		 	</cores>
+		      </emulator>
+		   </emulators>
+		<platform>arcade</platform>
+		<theme>arcade</theme>
+	</system>
+	<system>
+		<name>cps1</name>
+		<fullname>Arcade - CP System I</fullname>
+		<path>/roms/cps1/</path>
+		<extension>.zip .ZIP .7z .7Z .cue .CUE</extension>
+		<command>sudo perfmax; /usr/local/bin/%EMULATOR% -L /home/ark/.config/%EMULATOR%/cores/%CORE%_libretro.so %ROM%; sudo perfnorm</command>
+		   <emulators>
+		      <emulator name="retroarch">
+		 	<cores>
+		 	  <core>fbneo</core>
+		 	  <core>fbalpha2012</core>
+		 	</cores>
+		      </emulator>
+		      <emulator name="retroarch32">
+		 	<cores>
+		 	  <core>fbalpha2016</core>
+		 	  <core>fbalpha2018</core>
+		 	</cores>
+		      </emulator>
+		   </emulators>
+		<platform>arcade</platform>
+		<theme>cps1</theme>
+	</system>
+	<system>
+		<name>cps2</name>
+		<fullname>Arcade - CP System II</fullname>
+		<path>/roms/cps2/</path>
+		<extension>.zip .ZIP .7z .7Z .cue .CUE</extension>
+		<command>sudo perfmax; /usr/local/bin/%EMULATOR% -L /home/ark/.config/%EMULATOR%/cores/%CORE%_libretro.so %ROM%; sudo perfnorm</command>
+		   <emulators>
+		      <emulator name="retroarch">
+		 	<cores>
+		 	  <core>fbneo</core>
+		 	  <core>fbalpha2012</core>
+		 	</cores>
+		      </emulator>
+		      <emulator name="retroarch32">
+		 	<cores>
+		 	  <core>fbalpha2016</core>
+		 	  <core>fbalpha2018</core>
+		 	</cores>
+		      </emulator>
+		   </emulators>
+		<platform>arcade</platform>
+		<theme>cps2</theme>
+	</system>
+	<system>
+		<name>cps3</name>
+		<fullname>Arcade - CP System III</fullname>
+		<path>/roms/cps3/</path>
+		<extension>.zip .ZIP .7z .7Z .cue .CUE</extension>
+		<command>sudo perfmax; /usr/local/bin/%EMULATOR% -L /home/ark/.config/%EMULATOR%/cores/%CORE%_libretro.so %ROM%; sudo perfnorm</command>
+		   <emulators>
+		      <emulator name="retroarch">
+		 	<cores>
+		 	  <core>fbneo</core>
+		 	  <core>fbalpha2012</core>
+		 	</cores>
+		      </emulator>
+		      <emulator name="retroarch32">
+		 	<cores>
+		 	  <core>fbalpha2016</core>
+		 	  <core>fbalpha2018</core>
+		 	</cores>
+		      </emulator>
+		   </emulators>
+		<platform>arcade</platform>
+		<theme>cps3</theme>
+	</system>
+	<system>
+		<name>mame2003</name>
+		<fullname>Arcade - MAME2003</fullname>
+		<path>/roms/mame2003/</path>
+		<extension>.zip .ZIP .7z .7Z</extension>
+		<command>sudo perfmax; /usr/local/bin/retroarch -L /home/ark/.config/retroarch/cores/mame2003_plus_libretro.so %ROM%; sudo perfnorm</command>
+		<platform>arcade</platform>
+		<theme>mame2003</theme>
+	</system>
+	<system>
+		<name>mame2010</name>
+		<fullname>Arcade - MAME2010</fullname>
+		<path>/roms/mame/</path>
+		<extension>.zip .ZIP .7z .7Z .chd .CHD</extension>
+		<command>sudo perfmax; /usr/local/bin/retroarch -L /home/ark/.config/retroarch/cores/mame2010_libretro.so %ROM%; sudo perfnorm</command>
+		<platform>arcade</platform>
+		<theme>mame</theme>
+	</system>	
+	<system>
+		<name>Sega Atomiswave</name>
+		<fullname>Sega Atomiswave</fullname>
+		<path>/roms/atomiswave/</path>
+		<extension>.7z .7Z .ist .IST .zip .ZIP .bin .BIN</extension>
+		<command>sudo perfmax; /usr/local/bin/%EMULATOR% -L /home/ark/.config/%EMULATOR%/cores/%CORE%_libretro.so %ROM%; sudo perfnorm</command>
+		   <emulators>
+		      <emulator name="retroarch">
+		 	<cores>
+			  <core>flycast</core>
+		 	</cores>
+		      </emulator>
+		      <emulator name="retroarch32">
+		 	<cores>
+		 	  <core>flycast_xtreme</core>
+		 	  <core>reicast_xtreme</core>
+		 	</cores>
+		      </emulator>
+		   </emulators>
+		<platform>arcade</platform>
+		<theme>atomiswave</theme>
+	</system>
+	<system>
+		<name>Sega Naomi</name>
+		<fullname>Sega Naomi</fullname>
+		<path>/roms/naomi/</path>
+		<extension>.7z .7Z .ist .IST .zip .ZIP .bin .BIN .dat .DAT .m3u .M3U</extension>
+		<command>sudo perfmax; /usr/local/bin/%EMULATOR% -L /home/ark/.config/%EMULATOR%/cores/%CORE%_libretro.so %ROM%; sudo perfnorm</command>
+		   <emulators>
+		      <emulator name="retroarch">
+		 	<cores>
+		 	  <core>flycast</core>
+		 	</cores>
+		      </emulator>
+		      <emulator name="retroarch32">
+		 	<cores>
+		 	  <core>flycast_xtreme</core>
+		 	  <core>reicast_xtreme</core>
+		 	</cores>
+		      </emulator>
+		   </emulators>
+		<platform>arcade</platform>
+		<theme>naomi</theme>
+	</system>	
+	<system>
+		<name>atari800</name>
+		<fullname>Atari - 800</fullname>
+		<path>/roms/atari800/</path>
+		<extension>.atr .ATR .rom .ROM .zip .ZIP</extension>
+		<command>sudo perfmax; /usr/local/bin/retroarch -L /home/ark/.config/retroarch/cores/atari800_libretro.so %ROM%; sudo perfnorm</command>
+		<platform>atari800</platform>
+		<theme>atari800</theme>
+	</system>	
+	<system>
+		<name>atari2600</name>
+		<fullname>Atari - 2600</fullname>
+		<path>/roms/atari2600/</path>
+		<extension>.a26 .A26 .bin .BIN .zip .ZIP</extension>
+		<command>sudo perfmax; /usr/local/bin/retroarch -L /home/ark/.config/retroarch/cores/stella2014_libretro.so %ROM%; sudo perfnorm</command>
+		<platform>atari2600</platform>
+		<theme>atari2600</theme>
+	</system>
+	<system>
+		<name>atari5200</name>
+		<fullname>Atari 5200</fullname>
+		<path>/roms/atari5200/</path>
+		<extension>.a52 .A52 .zip .ZIP</extension>
+		<command>sudo perfmax; /usr/local/bin/retroarch -L /home/ark/.config/retroarch/cores/atari800_libretro.so %ROM%; sudo perfnorm</command>
+		<platform>atari5200</platform>
+		<theme>atari5200</theme>
+	</system>
+	<system>
+		<name>atari7800</name>
+		<fullname>Atari - 7800</fullname>
+		<path>/roms/atari7800/</path>
+		<extension>.a78 .A78 .zip .ZIP .7z .7Z</extension>
+		<command>sudo perfmax; /usr/local/bin/retroarch -L /home/ark/.config/retroarch/cores/prosystem_libretro.so %ROM%; sudo perfnorm</command>
+		<platform>atari7800</platform>
+		<theme>atari7800</theme>
+	</system>
+	<system>
+		<name>atarist</name>
+		<fullname>Atari ST</fullname>
+		<path>/roms/atarist/</path>
+		<extension>.st .ST .msa .MSA .stx .STX .dim .DIM .ipf .IPF .zip .ZIP</extension>
+		<command>/usr/local/bin/retroarch -L /home/ark/.config/retroarch/cores/hatari_libretro.so %ROM%</command>
+		<platform>atarist</platform>
+		<theme>atarist</theme>
+	</system>
+	<system>
+		<name>atarixegs</name>
+		<fullname>Atari - XEGS</fullname>
+		<path>/roms/atarixegs/</path>
+		<extension>.rom .ROM .bin .BIN .xex .XEX .zip .ZIP</extension>
+		<command>sudo perfmax; /usr/local/bin/retroarch -L /home/ark/.config/retroarch/cores/atari800_libretro.so %ROM%; sudo perfnorm</command>
+		<platform>atarixegs</platform>
+		<theme>atarixegs</theme>
+	</system>	
+	<system>
+		<name>atarilynx</name>
+		<fullname>Atari - Lynx</fullname>
+		<path>/roms/atarilynx/</path>
+		<extension>.lnx .LNX .zip .ZIP</extension>
+		<command>sudo perfmax; /usr/local/bin/%EMULATOR% -L /home/ark/.config/%EMULATOR%/cores/%CORE%_libretro.so %ROM%; sudo perfnorm</command>
+		   <emulators>
+		      <emulator name="retroarch32">
+		 	<cores>
+		 	  <core>handy</core>
+		 	</cores>
+		      </emulator>
+		      <emulator name="retroarch">
+		 	<cores>
+		 	  <core>handy</core>
+		 	  <core>mednafen_lynx</core>
+		 	</cores>
+		      </emulator>
+		   </emulators>
+		<platform>atarilynx</platform>
+		<theme>atarilynx</theme>
+	</system>	
+	<system>
+		<name>wonderswan</name>
+		<fullname>Bandai - WonderSwan</fullname>
+		<path>/roms/wonderswan/</path>
+		<extension>.ws .WS .wsc .WSC .pc2 .PC2 .zip .ZIP .7z .7Z</extension>
+		<command>sudo perfmax; /usr/local/bin/retroarch -L /home/ark/.config/retroarch/cores/mednafen_wswan_libretro.so %ROM%; sudo perfnorm</command>
+		<platform>wonderswan</platform>
+		<theme>wonderswan</theme>
+	</system>
+	<system>
+		<name>wonderswancolor</name>
+		<fullname>Bandai - WonderSwan Color</fullname>
+		<path>/roms/wonderswancolor/</path>
+		<extension>.ws .WS .wsc .WSC .pc2 .PC2 .zip .ZIP .7z .7Z</extension>
+		<command>sudo perfmax; /usr/local/bin/retroarch -L /home/ark/.config/retroarch/cores/mednafen_wswan_libretro.so %ROM%; sudo perfnorm</command>
+		<platform>wonderswancolor</platform>
+		<theme>wonderswancolor</theme>
+	</system>
+	<system>
+		<name>odyssey2</name>
+		<fullname>Magnavox - Odyssey2</fullname>
+		<path>/roms/odyssey2/</path>
+		<extension>.bin .BIN</extension>
+		<command>sudo perfmax; /usr/local/bin/retroarch -L /home/ark/.config/retroarch/cores/o2em_libretro.so %ROM%; sudo perfnorm</command>
+		<platform>odyssey2</platform>
+		<theme>odyssey2</theme>
+	</system>		
+	<system>
+		<name>pcengine</name>
+		<fullname>NEC - PCEngine</fullname>
+		<path>/roms/pcengine/</path>
+		<extension>.pce .PCE .bin .BIN .ccd .CCD .iso .ISO .img .IMG .chd .CHD .zip .ZIP .cue .CUE .m3u .M3U</extension>
+		<command>sudo perfmax; /usr/local/bin/%EMULATOR% -L /home/ark/.config/%EMULATOR%/cores/%CORE%_libretro.so %ROM%; sudo perfnorm</command>
+		   <emulators>
+		      <emulator name="retroarch">
+		 	<cores>
+		 	  <core>mednafen_pce_fast</core>
+		 	  <core>mednafen_supergrafx</core>
+		 	  <core>mednafen_pce</core>
+		 	</cores>
+		      </emulator>
+		   </emulators>
+		<platform>pcengine</platform>
+		<theme>pcengine</theme>
+	</system>
+	<system>
+		<name>pcenginecd</name>
+		<fullname>NEC - PCEngineCD</fullname>
+		<path>/roms/pcenginecd/</path>
+		<extension>.pce .PCE .ccd .CCD .iso .ISO .img .IMG .chd .CHD .zip .ZIP .cue .CUE .m3u .M3U</extension>
+		<command>sudo perfmax; /usr/local/bin/%EMULATOR% -L /home/ark/.config/%EMULATOR%/cores/%CORE%_libretro.so %ROM%; sudo perfnorm</command>
+		   <emulators>
+		      <emulator name="retroarch">
+		 	<cores>
+		 	  <core>mednafen_pce_fast</core>
+		 	  <core>mednafen_supergrafx</core>
+		 	  <core>mednafen_pce</core>
+		 	</cores>
+		      </emulator>
+		   </emulators>
+		<platform>pcenginecd</platform>
+		<theme>pcenginecd</theme>
+	</system>
+	<system>
+		<name>turbografx16</name>
+		<fullname>Turbografx 16</fullname>
+		<path>/roms/turbografx</path>
+		<extension>.pce .PCE .bin .BIN .ccd .CCD .iso .ISO .img .IMG .chd .CHD .zip .ZIP .cue .CUE .m3u .M3U</extension>
+		<command>sudo perfmax; /usr/local/bin/%EMULATOR% -L /home/ark/.config/%EMULATOR%/cores/%CORE%_libretro.so %ROM%; sudo perfnorm</command>
+		   <emulators>
+		      <emulator name="retroarch">
+		 	<cores>
+		 	  <core>mednafen_pce_fast</core>
+		 	  <core>mednafen_supergrafx</core>
+		 	  <core>mednafen_pce</core>
+		 	</cores>
+		      </emulator>
+		   </emulators>
+		<platform>pcengine</platform>
+		<theme>tg16</theme>
+	</system>
+	<system>
+		<name>TurbografxCD</name>
+		<fullname>Turbografx CD</fullname>
+		<path>/roms/turbografxcd</path>
+		<extension>.pce .PCE .ccd .CCD .iso .ISO .img .IMG .chd .CHD .zip .ZIP .cue .CUE .m3u .M3U</extension>
+		<command>sudo perfmax; /usr/local/bin/%EMULATOR% -L /home/ark/.config/%EMULATOR%/cores/%CORE%_libretro.so %ROM%; sudo perfnorm</command>
+		   <emulators>
+		      <emulator name="retroarch">
+		 	<cores>
+		 	  <core>mednafen_pce_fast</core>
+		 	  <core>mednafen_supergrafx</core>
+		 	  <core>mednafen_pce</core>
+		 	</cores>
+		      </emulator>
+		   </emulators>
+		<platform>pcenginecd</platform>
+		<theme>tg-cd</theme>
+	</system>	
+	<system>
+		<name>supergrafx</name>
+		<fullname>NEC - Super Grafx</fullname>
+		<path>/roms/supergrafx/</path>
+		<extension>.pce .PCE .sgx .SGX .bin .BIN .ccd .CCD .iso .ISO .img .IMG .chd .CHD .zip .ZIP .cue .CUE .m3u .M3U</extension>
+		<command>sudo perfmax; /usr/local/bin/%EMULATOR% -L /home/ark/.config/%EMULATOR%/cores/%CORE%_libretro.so %ROM%; sudo perfnorm</command>
+		   <emulators>
+		      <emulator name="retroarch">
+		 	<cores>
+		 	  <core>mednafen_supergrafx</core>
+		 	  <core>mednafen_pce</core>
+		 	</cores>
+		      </emulator>
+		   </emulators>
+		<platform>supergrafx</platform>
+		<theme>supergrafx</theme>
+	</system>	
+	<system>
+		<name>famicom</name>
+		<fullname>Nintendo - Famicom</fullname>
+		<path>/roms/famicom/</path>
+		<extension>.nes .NES .unif .UNIF .unf .UNF .zip .ZIP .7z .7Z</extension>
+		<command>sudo perfmax; /usr/local/bin/retroarch -L /home/ark/.config/retroarch/cores/nestopia_libretro.so %ROM%; sudo perfnorm</command>
+		<platform>nes</platform>
+		<theme>famicom</theme>
+	</system>
+	<system>
+		<name>famicom disk system</name>
+		<fullname>Nintendo - Famicom Disk System</fullname>
+		<path>/roms/fds/</path>
+		<extension>.nes .NES .unif .UNIF .unf .UNF .fds .FDS .zip .ZIP .7z .7Z</extension>
+		<command>sudo perfmax; /usr/local/bin/%EMULATOR% -L /home/ark/.config/%EMULATOR%/cores/%CORE%_libretro.so %ROM%; sudo perfnorm</command>
+		   <emulators>
+		      <emulator name="retroarch">
+		 	<cores>
+		 	  <core>nestopia</core>
+		 	  <core>fceumm</core>
+		 	</cores>
+		      </emulator>
+		   </emulators>
+		<platform>fds</platform>
+		<theme>fds</theme>
+	</system>
+	<system>
+		<name>sfc</name>
+		<fullname>Nintendo - Super Famicom</fullname>
+		<path>/roms/sfc/</path>
+		<extension>.sfc .SFC .smc .SMC .zip .ZIP .7z .7Z</extension>
+		<command>sudo perfmax; /usr/local/bin/%EMULATOR% -L /home/ark/.config/%EMULATOR%/cores/%CORE%_libretro.so %ROM%; sudo perfnorm</command>
+		   <emulators>
+		      <emulator name="retroarch">
+		 	<cores>
+		 	  <core>snes9x</core>
+		 	  <core>snes9x2010</core>
+		 	</cores>
+		      </emulator>
+		      <emulator name="retroarch32">
+		 	<cores>
+		 	  <core>snes9x2002</core>
+		 	  <core>snes9x2005</core>
+		 	</cores>
+		      </emulator>
+		   </emulators>
+		<platform>snes</platform>
+		<theme>sfc</theme>
+	</system>
+	<system>
+		<name>Nintendo Entertainment System</name>
+		<fullname>Nintendo - NES</fullname>
+		<path>/roms/nes/</path>
+		<extension>.nes .NES .zip .ZIP</extension>
+		<command>sudo perfmax; /usr/local/bin/%EMULATOR% -L /home/ark/.config/%EMULATOR%/cores/%CORE%_libretro.so %ROM%; sudo perfnorm</command>
+		   <emulators>
+		      <emulator name="retroarch">
+		 	<cores>
+		 	  <core>nestopia</core>
+		 	  <core>fceumm</core>
+		 	</cores>
+		      </emulator>
+		   </emulators>
+		<platform>nes</platform>
+		<theme>nes</theme>
+	</system>	
+	<system>
+		<name>snes</name>
+		<fullname>Nintendo - SuFami Turbo</fullname>
+		<path>/roms/sufami/</path>
+		<extension>.smc .SMC .zip .ZIP .7z .7Z</extension>
+		<command>sudo perfmax; /usr/local/bin/%EMULATOR% -L /home/ark/.config/%EMULATOR%/cores/%CORE%_libretro.so %ROM%; sudo perfnorm</command>
+		   <emulators>
+		      <emulator name="retroarch">
+		 	<cores>
+		 	  <core>snes9x2010</core>
+		 	  <core>snes9x</core>
+		 	</cores>
+		      </emulator>
+		      <emulator name="retroarch32">
+		 	<cores>
+		 	  <core>snes9x2002</core>
+		 	  <core>snes9x2005</core>
+		 	</cores>
+		      </emulator>
+		   </emulators>
+		<platform>snes</platform>
+		<theme>sufami</theme>
+	</system>
+	<system>
+		<name>Super Nintendo</name>
+		<fullname>Nintendo - Super NES</fullname>
+		<path>/roms/snes/</path>
+		<extension>.smc .SMC .sfc .SFC .fig .FIG .zip .ZIP .7z .7Z</extension>
+		<command>sudo perfmax; /usr/local/bin/%EMULATOR% -L /home/ark/.config/%EMULATOR%/cores/%CORE%_libretro.so %ROM%; sudo perfnorm</command>
+		   <emulators>
+		      <emulator name="retroarch">
+		 	<cores>
+		 	  <core>snes9x</core>
+		 	  <core>snes9x2010</core>
+		 	</cores>
+		      </emulator>
+		      <emulator name="retroarch32">
+		 	<cores>
+		 	  <core>snes9x2002</core>
+		 	  <core>snes9x2005</core>
+		 	</cores>
+		      </emulator>
+		   </emulators>
+		<platform>snes</platform>
+		<theme>snes</theme>
+	</system>		
+	<system>
+		<name>Super Nintendo MSU1</name>
+		<fullname>Nintendo - Super NES CD</fullname>
+		<path>/roms/snesmsu1/</path>
+		<extension>.smc .SMC .sfc .SFC .zip .ZIP .7z .7Z</extension>
+		<command>sudo perfmax; /usr/local/bin/retroarch -L /home/ark/.config/retroarch/cores/snes9x_libretro.so %ROM%; sudo perfnorm</command>
+		<platform>snes</platform>
+		<theme>snesmsu1</theme>
+	</system>
+	<system>
+		<name>snes-hacks</name>
+		<fullname>Nintendo - Super Famicom 2010</fullname>
+		<path>/roms/snes-hacks/</path>
+		<extension>.smc .SMC .fig .FIG .bs .BS .st .ST .sfc .SFC .gd3 .GD3 .gd7 .GD7 .dx2 .DX2 .bsx .BSX .swc .SWC .zip .ZIP .7z .7Z</extension>
+		<command>sudo perfmax; /usr/local/bin/retroarch -L /home/ark/.config/retroarch/cores/snes9x2010_libretro.so %ROM%; sudo perfnorm</command>
+		<platform>snes</platform>
+		<theme>snes-hacks</theme>
+	</system>		
+	<system>
+		<name>N64</name>
+		<fullname>Nintendo - 64</fullname>
+		<path>/roms/n64/</path>
+		<extension>.z64 .Z64 .n64 .N64 .v64 .V64</extension>
+		<command>sudo perfmax; /usr/local/bin/n64.sh %EMULATOR% %CORE% %ROM%; sudo perfnorm</command>
+		   <emulators>
+		      <emulator name="retroarch32">
+		 	<cores>
+		 	  <core>parallel_n64</core>
+		 	</cores>
+		      </emulator>
+		      <emulator name="retroarch">
+		 	<cores>
+		 	  <core>parallel_n64</core>
+		 	  <core>mupen64plus_next</core>
+			  <core>glupen64</core>
+		 	</cores>
+		      </emulator>
+		      <emulator name="standalone-Rice">
+		      </emulator>			  
+              <emulator name="standalone-Glide64mk2">
+              </emulator>
+		   </emulators>
+		<platform>n64</platform>
+		<theme>n64</theme>
+	</system>
+    <system>
+    	<name>N64DD</name>
+    	<fullname>Nintendo 64DD</fullname>
+    	<path>/roms/n64dd/</path>
+    	<extension>.n64 .N64 .z64 .Z64</extension>
+    	<command>sudo perfmax; /usr/local/bin/%EMULATOR% -L /home/ark/.config/%EMULATOR%/cores/%CORE%_libretro.so %ROM%; sudo perfnorm</command>
+	   <emulators>
+	      <emulator name="retroarch32">
+	 	<cores>
+	 	  <core>parallel_n64</core>
+	 	</cores>
+	      </emulator>
+	      <emulator name="retroarch">
+	 	<cores>
+	 	  <core>parallel_n64</core>
+	 	  <core>mupen64plus_next</core>
+		  <core>glupen64</core>
+	 	</cores>
+	      </emulator>
+	   </emulators>
+       	<platform>n64dd</platform>
+		<theme>n64dd</theme>
+    </system>
+	<system>
+		<name>virtualboy</name>
+		<fullname>Nintendo - Virtualboy</fullname>
+		<path>/roms/virtualboy/</path>
+		<extension>.vb .VB .vboy .VBOY .zip .zip</extension>
+		<command>sudo perfmax; /usr/local/bin/retroarch -L /home/ark/.config/retroarch/cores/mednafen_vb_libretro.so %ROM%; sudo perfnorm</command>
+		<platform>virtualboy</platform>
+		<theme>virtualboy</theme>
+	</system>		
+	<system>
+		<name>gb</name>
+		<fullname>Nintendo - GB</fullname>
+		<path>/roms/gb/</path>
+		<extension>.gb .GB .gbc .GBC .dmg .DMG .zip .ZIP .7z .7Z</extension>
+		<command>sudo perfmax; /usr/local/bin/%EMULATOR% -L /home/ark/.config/%EMULATOR%/cores/%CORE%_libretro.so %ROM%; sudo perfnorm</command>
+		   <emulators>
+		      <emulator name="retroarch">
+		 	<cores>
+		 	  <core>gambatte</core>
+			  <core>mgba_rumble</core>
+			  <core>tgbdual</core>
+		 	</cores>
+		      </emulator>
+		   </emulators>
+		<platform>gb</platform>
+		<theme>gb</theme>
+	</system>
+	<system>
+		<name>gbc</name>
+		<fullname>Nintendo - GBC</fullname>
+		<path>/roms/gbc/</path>
+		<extension>.gb .GB .gbc .GBC .dmg .DMG .zip .ZIP .7z .7Z</extension>
+		<command>sudo perfmax; /usr/local/bin/%EMULATOR% -L /home/ark/.config/%EMULATOR%/cores/%CORE%_libretro.so %ROM%; sudo perfnorm</command>
+		   <emulators>
+		      <emulator name="retroarch">
+		 	<cores>
+		 	  <core>gambatte</core>
+			  <core>mgba_rumble</core>
+			  <core>tgbdual</core>
+		 	</cores>
+		      </emulator>
+		   </emulators>
+		<platform>gbc</platform>
+		<theme>gbc</theme>
+	</system>
+	<system>
+		<name>gba</name>
+		<fullname>Nintendo - GBA</fullname>
+		<path>/roms/gba/</path>
+		<extension>.gb .GB .gbc .GBC .gba .GBA .zip .ZIP .7z .7Z</extension>
+		<command>sudo perfmax; /usr/local/bin/%EMULATOR% -L /home/ark/.config/%EMULATOR%/cores/%CORE%_libretro.so %ROM%; sudo perfnorm</command>
+		   <emulators>
+		      <emulator name="retroarch">
+		 	<cores>
+		 	  <core>mgba_rumble</core>
+			  <core>mgba</core>
+			  <core>vbam</core>
+			  <core>vba_next</core>
+		 	</cores>
+		      </emulator>
+		   </emulators>
+		<platform>gba</platform>
+		<theme>gba</theme>
+	</system>
+	<system>
+		<name>gameandwatch</name>
+		<fullname>Nintendo - Game and Watch</fullname>
+		<path>/roms/gameandwatch</path>
+		<extension>.mgw .MGW</extension>
+		<command>sudo perfmax; /usr/local/bin/retroarch -L /home/ark/.config/retroarch/cores/gw_libretro.so %ROM%; sudo perfnorm</command>
+		<platform>gameandwatch</platform>
+		<theme>gameandwatch</theme>
+	</system>
+	<system>
+		<name>sgb</name>
+		<fullname>Nintendo - SGB</fullname>
+		<path>/roms/sgb/</path>
+		<extension>.gb .GB .gbc .GBC .dmg .DMG .zip .ZIP .7z .7Z</extension>
+		<command>sudo perfmax; /usr/local/bin/retroarch -L /home/ark/.config/retroarch/cores/mgba_libretro.so %ROM%; sudo perfnorm</command>
+		<platform>sgb</platform>
+		<theme>sgb</theme>
+	</system>
+	<system>
+		<name>nds</name>
+		<fullname>Nintendo DS</fullname>
+		<path>/roms/nds/</path>
+		<extension>.zip .ZIP .nds .NDS</extension>
+		<command>sudo perfmax; cd /; cd /opt/drastic; ./drastic %ROM%; sudo perfnorm</command>
+		<platform>nds</platform>
+		<theme>nds</theme>
+	</system>	
+	<system>
+		<name>sg-1000</name>
+		<fullname>Sega - SG-1000</fullname>
+		<path>/roms/sg-1000/</path>
+		<extension>.mdx .MDX .md .MD .smd .SMD .gen .GEN .bin .BIN .cue .CUE .iso .ISO .sms .SMS .gg .GG .sg .SG .68k .68K .chd .CHD .zip .ZIP .7z .7Z</extension>
+		<command>sudo perfmax; /usr/local/bin/retroarch -L /home/ark/.config/retroarch/cores/genesis_plus_gx_libretro.so %ROM%; sudo perfnorm</command>
+		<platform>sg1000</platform>
+		<theme>sg-1000</theme>
+	</system>
+	<system>
+		<name>mastersystem</name>
+		<fullname>Sega - Master System</fullname>
+		<path>/roms/mastersystem/</path>
+		<extension>.mdx .MDX .md .MD .smd .SMD .gen .GEN .bin .BIN .cue .CUE .iso .ISO .sms .SMS .gg .GG .sg .SG .68k .68K .chd .CHD .zip .ZIP .7z .7Z</extension>
+		<command>sudo perfmax; /usr/local/bin/%EMULATOR% -L /home/ark/.config/%EMULATOR%/cores/%CORE%_libretro.so %ROM%; sudo perfnorm</command>
+		   <emulators>
+		      <emulator name="retroarch">
+		 	<cores>
+		 	  <core>genesis_plus_gx</core>
+		 	  <core>picodrive</core>
+		 	</cores>
+		      </emulator>
+		      <emulator name="retroarch32">
+		 	<cores>
+		 	  <core>picodrive</core>
+		 	</cores>
+		      </emulator>
+		   </emulators>
+		<platform>mastersystem</platform>
+		<theme>mastersystem</theme>
+	</system>
+	<system>
+		<name>megadrive</name>
+		<fullname>Sega - Megadrive</fullname>
+		<path>/roms/megadrive/</path>
+		<extension>.mdx .MDX .md .MD .smd .SMD .gen .GEN .bin .BIN .cue .CUE .iso .ISO .sms .SMS .gg .GG .sg .SG .68k .68K .chd .CHD .zip .ZIP .7z .7Z .m3u .M3U</extension>
+		<command>sudo perfmax; /usr/local/bin/%EMULATOR% -L /home/ark/.config/%EMULATOR%/cores/%CORE%_libretro.so %ROM%; sudo perfnorm</command>
+		   <emulators>
+		      <emulator name="retroarch">
+		 	<cores>
+		 	  <core>genesis_plus_gx</core>
+		 	  <core>picodrive</core>
+		 	</cores>
+		      </emulator>
+		      <emulator name="retroarch32">
+		 	<cores>
+		 	  <core>picodrive</core>
+		 	</cores>
+		      </emulator>
+		   </emulators>
+		<platform>megadrive</platform>
+		<theme>megadrive</theme>
+	</system>
+	<system>
+		<name>genesis</name>
+		<fullname>Sega - Genesis</fullname>
+		<path>/roms/genesis/</path>
+		<extension>.mdx .MDX .md .MD .smd .SMD .gen .GEN .bin .BIN .cue .CUE .iso .ISO .sms .SMS .gg .GG .sg .SG .68k .68K .chd .CHD .zip .ZIP .7z .7Z .m3u .M3U</extension>
+		<command>sudo perfmax; /usr/local/bin/%EMULATOR% -L /home/ark/.config/%EMULATOR%/cores/%CORE%_libretro.so %ROM%; sudo perfnorm</command>
+		   <emulators>
+		      <emulator name="retroarch">
+		 	<cores>
+		 	  <core>genesis_plus_gx</core>
+		 	  <core>picodrive</core>
+		 	</cores>
+		      </emulator>
+		      <emulator name="retroarch32">
+		 	<cores>
+		 	  <core>picodrive</core>
+		 	</cores>
+		      </emulator>
+		   </emulators>
+		<platform>genesis</platform>
+		<theme>genesis</theme>
+	</system>
+	<system>
+		<name>segacd</name>
+		<fullname>Sega - CD</fullname>
+		<path>/roms/segacd/</path>
+		<extension>.mdx .MDX .md .MD .smd .SMD .gen .GEN .cue .CUE .iso .ISO .sms .SMS .gg .GG .sg .SG .68k .68K .chd .CHD .zip .ZIP .7z .7Z .m3u .M3U</extension>
+		<command>sudo perfmax; /usr/local/bin/%EMULATOR% -L /home/ark/.config/%EMULATOR%/cores/%CORE%_libretro.so %ROM%; sudo perfnorm</command>
+		   <emulators>
+		      <emulator name="retroarch">
+		 	<cores>
+		 	  <core>genesis_plus_gx</core>
+		 	  <core>picodrive</core>
+		 	</cores>
+		      </emulator>
+		      <emulator name="retroarch32">
+		 	<cores>
+		 	  <core>picodrive</core>
+		 	</cores>
+		      </emulator>
+		   </emulators>
+		<platform>segacd</platform>
+		<theme>segacd</theme>
+	</system>
+	<system>
+		<name>sega32x</name>
+		<fullname>Sega - 32X</fullname>
+		<path>/roms/sega32x/</path>
+		<extension>.32x .32X .smd .SMD .bin .BIN .md .MD .gen .GEN .cue .CUE .iso .ISO .sms .SMS .68k .68K .zip .ZIP .7z .7Z .m3u .M3U</extension>
+		<command>sudo perfmax; /usr/local/bin/%EMULATOR% -L /home/ark/.config/%EMULATOR%/cores/%CORE%_libretro.so %ROM%; sudo perfnorm</command>
+		   <emulators>
+		      <emulator name="retroarch">
+		 	<cores>
+		 	  <core>picodrive</core>
+		 	</cores>
+		      </emulator>
+		      <emulator name="retroarch32">
+		 	<cores>
+		 	  <core>picodrive</core>
+		 	</cores>
+		      </emulator>
+		   </emulators>
+		<platform>sega32x</platform>
+		<theme>sega32x</theme>
+	</system>
+	<system>
+		<name>Sega Saturn</name>
+		<fullname>Sega Saturn</fullname>
+		<path>/roms/saturn/</path>
+		<extension>.img .IMG .cue .CUE .chd .CHD .iso .ISO .m3u .M3U</extension>
+		<command>sudo perfmax; /usr/local/bin/%EMULATOR% -L /home/ark/.config/%EMULATOR%/cores/%CORE%_libretro.so %ROM%; sudo perfnorm</command>
+		   <emulators>
+		      <emulator name="retroarch32">
+		 	<cores>
+		 	  <core>yabasanshiro</core>
+		 	  <core>yabause</core>
+		 	</cores>
+		      </emulator>
+		      <emulator name="retroarch">
+		 	<cores>
+		 	  <core>yabause</core>
+		 	</cores>
+		      </emulator>
+		   </emulators>
+		<platform>console</platform>
+		<theme>saturn</theme>
+	</system>	
+	<system>
+		<name>dreamcast</name>
+		<fullname>Sega Dreamcast</fullname>
+		<path>/roms/dreamcast/</path>
+		<extension>.7z .7Z .gdi .GDI .cdi .CDI .cue .CUE .chd .CHD .m3u .M3U</extension>
+		<command>sudo perfmax; /usr/local/bin/%EMULATOR% -L /home/ark/.config/%EMULATOR%/cores/%CORE%_libretro.so %ROM%; echo 1000000 > /sys/class/pwm/pwmchip0/pwm0/duty_cycle; sudo perfnorm</command>
+		   <emulators>
+		      <emulator name="retroarch">
+		 	<cores>
+		 	  <core>flycast_rumble</core>
+		 	  <core>flycast</core>
+		 	</cores>
+		      </emulator>
+		      <emulator name="retroarch32">
+		 	<cores>
+		 	  <core>flycast_xtreme</core>
+		 	  <core>reicast_xtreme</core>
+		 	</cores>
+		      </emulator>
+		   </emulators>
+		<platform>dreamcast</platform>
+		<theme>dreamcast</theme>
+	</system>
+	<system>
+		<name>vmu</name>
+		<fullname>Sega Dreamcast VMU</fullname>
+		<path>/roms/vmu/</path>
+		<extension>.vms .VMS .bin .BIN</extension>
+		<command>sudo perfmax; /usr/local/bin/retroarch -L /home/ark/.config/retroarch/cores/vemulator_libretro.so %ROM%; sudo perfnorm</command>
+		<platform>vmu</platform>
+		<theme>vmu</theme>
+	</system>	
+	<system>
+		<name>gamegear</name>
+		<fullname>Sega - Game Gear</fullname>
+		<path>/roms/gamegear/</path>
+		<extension>.bin .BIN .gg .GG .zip .ZIP .7z .7Z</extension>
+		<command>sudo perfmax; /usr/local/bin/retroarch -L /home/ark/.config/retroarch/cores/genesis_plus_gx_libretro.so %ROM%; sudo perfnorm</command>
+		<platform>gamegear</platform>
+		<theme>gamegear</theme>
+	</system>
+	<system>
+		<name>neogeo</name>
+		<fullname>Arcade - Neogeo</fullname>
+		<path>/roms/neogeo/</path>
+		<extension>.zip .ZIP .7z .7Z .cue .CUE</extension>
+		<command>sudo perfmax; /usr/local/bin/%EMULATOR% -L /home/ark/.config/%EMULATOR%/cores/%CORE%_libretro.so %ROM%; sudo perfnorm</command>
+		   <emulators>
+		      <emulator name="retroarch">
+		 	<cores>
+		 	  <core>fbneo</core>
+		 	  <core>fbalpha2012</core>
+		 	</cores>
+		      </emulator>
+		   </emulators>
+		<platform>neogeo</platform>
+		<theme>neogeo</theme>
+	</system>
+	<system>
+        <name>neogeocd</name>
+        <fullname>SNK - Neo Geo CD</fullname>
+        <path>/roms/neogeocd/</path>
+        <extension>.cue .CUE .chd .CHD .m3u .M3U</extension>
+        <command>sudo perfmax; /usr/local/bin/retroarch -L /home/ark/.config/retroarch/cores/neocd_libretro.so %ROM%; sudo perfnorm</command>
+        <platform>console</platform>
+        <theme>neogeocd</theme>
+    </system>	
+	<system>
+		<name>ngp</name>
+		<fullname>SNK - Neo Geo Pocket</fullname>
+		<path>/roms/ngp/</path>
+		<extension>.ngp .NGP .ngc .NGC .zip .ZIP</extension>
+		<command>sudo perfmax; /usr/local/bin/retroarch -L /home/ark/.config/retroarch/cores/mednafen_ngp_libretro.so %ROM%; sudo perfnorm</command>
+		<platform>ngp</platform>
+		<theme>ngp</theme>
+	</system>
+	<system>
+		<name>ngpc</name>
+		<fullname>SNK - Neo Geo Pocket Color</fullname>
+		<path>/roms/ngpc/</path>
+		<extension>.ngp .NGP .ngc .NGC .zip .ZIP</extension>
+		<command>sudo perfmax; /usr/local/bin/retroarch -L /home/ark/.config/retroarch/cores/mednafen_ngp_libretro.so %ROM%; sudo perfnorm</command>
+		<platform>ngpc</platform>
+		<theme>ngpc</theme>
+	</system>
+	<system>
+		<name>psx</name>
+		<fullname>Sony - PlayStation</fullname>
+		<path>/roms/psx/</path>
+		<extension>.cue .CUE .img .IMG .mdf .MDF .pbp .PBP .toc .TOC .cbn .CBN .m3u .M3U .ccd .CCD .chd .CHD .zip .ZIP .7z .7Z .iso .ISO</extension>
+		<command>sudo perfmax; /usr/local/bin/%EMULATOR% -L /home/ark/.config/%EMULATOR%/cores/%CORE%_libretro.so %ROM%; sudo perfnorm</command>
+		   <emulators>
+		      <emulator name="retroarch32">
+		 	<cores>
+		 	  <core>pcsx_rearmed</core>
+		 	</cores>
+		      </emulator>
+		      <emulator name="retroarch">
+		 	<cores>
+		 	  <core>duckstation</core>
+		 	</cores>
+		      </emulator>
+		   </emulators>
+		<platform>psx</platform>
+		<theme>psx</theme>
+	</system>
+	<system>
+		<name>ppsspp</name>
+		<fullname>Sony - PlayStation Portable</fullname>
+		<path>/roms/psp/</path>
+		<extension>.iso .ISO .cso .CSO .pbp .PBP .m3u .M3U</extension>
+		<command>sudo perfmax; /usr/local/bin/ppsspp.sh %EMULATOR% %ROM%; sudo perfnorm</command>
+		   <emulators>
+		      <emulator name="standalone">
+		      </emulator>
+		      <emulator name="standalone-go">
+		      </emulator>
+		      <emulator name="retroarch">
+		      </emulator>
+		   </emulators>
+		<platform>psp</platform>
+		<theme>psp</theme>
+	</system>
+	<system>
+		<name>pspminis</name>
+		<fullname>Sony - Playstation Portable Minis</fullname>
+		<path>/roms/pspminis/</path>
+		<extension>.iso .ISO .cso .CSO .pbp .PBP .m3u .M3U</extension>
+		<command>sudo perfmax; /usr/local/bin/ppsspp.sh %EMULATOR% %ROM%; sudo perfnorm</command>
+		   <emulators>
+		      <emulator name="standalone">
+		      </emulator>
+                      <emulator name="standalone-go">
+                      </emulator>
+		      <emulator name="retroarch">
+		      </emulator>
+		   </emulators>
+		<platform>psp</platform>
+		<theme>pspminis</theme>
+	</system>		
+    <system>
+		<name>Intellivision</name>
+		<fullname>Mattel Intellivision</fullname>
+		<path>/roms/intellivision/</path>
+		<extension>.bin .BIN .int .INT .zip .ZIP .7z .7Z</extension>
+		<command>sudo perfmax; /usr/local/bin/retroarch32 -L /home/ark/.config/retroarch32/cores/freeintv_libretro.so %ROM%; sudo perfnorm</command>
+		<platform>intellivision</platform>
+		<theme>intellivision</theme>
+	</system>		
+	<system>
+		<name>coleco</name>
+		<fullname>Coleco - ColecoVision</fullname>
+		<path>/roms/coleco/</path>
+		<extension>.rom .ROM .ri .RI .mx1 .MX1 .mx2 .MX2 .col .COL .dsk .DSK .cas .CAS .sg .SG .sc .SC .m3u .M3U .zip .ZIP</extension>
+		<command>sudo perfmax; /usr/local/bin/retroarch -L /home/ark/.config/retroarch/cores/bluemsx_libretro.so %ROM%; sudo perfnorm</command>
+		<platform>colecovision</platform>
+		<theme>colecovision</theme>
+	</system>
+	<system>
+		<name>Tic-80</name>
+		<fullname>Tic-80</fullname>
+		<path>/roms/tic80/</path>
+		<extension>.tic .TIC</extension>
+		<command>sudo perfmax; /usr/local/bin/retroarch -L /home/ark/.config/retroarch/cores/tic80_libretro.so %ROM%; sudo perfnorm</command>
+		<platform>tic-80</platform>
+		<theme>tic80</theme>	
+	</system>
+	<system>
+		<name>vectrex</name>
+		<fullname>Vectrex</fullname>
+		<path>/roms/vectrex/</path>
+		<extension>.vec .VEC .zip .ZIP</extension>
+		<command>sudo perfmax; /usr/local/bin/retroarch -L /home/ark/.config/retroarch/cores/vecx_libretro.so --fullscreen %ROM%; sudo perfnorm</command>
+		<platform>vectrex</platform>
+		<theme>vectrex</theme>	
+	</system>	
+    <system>
+		<name>msx</name>
+		<fullname>Microsoft MSX</fullname>
+		<path>/roms/msx/</path>
+		<extension>.cas .CAS .dsk .DSK .mx1 .MX1 .mx2 .MX2 .rom .ROM .zip .ZIP .m3u .M3U</extension>
+		<command>sudo perfmax; /usr/local/bin/%EMULATOR% -L /home/ark/.config/%EMULATOR%/cores/%CORE%_libretro.so %ROM%; sudo perfnorm</command>
+		   <emulators>
+		      <emulator name="retroarch">
+		 	<cores>
+		 	  <core>bluemsx</core>
+		 	  <core>fmsx</core>
+		 	</cores>
+		      </emulator>
+		   </emulators>
+		<platform>msx</platform>
+		<theme>msx</theme>
+	</system>
+    <system>
+		<name>msx2</name>
+		<fullname>Microsoft MSX 2</fullname>
+		<path>/roms/msx2/</path>
+		<extension>.cas .CAS .dsk .DSK .mx1 .MX1 .mx2 .MX2 .rom .ROM .zip .Zip .m3u .M3U</extension>
+		<command>sudo perfmax; /usr/local/bin/%EMULATOR% -L /home/ark/.config/%EMULATOR%/cores/%CORE%_libretro.so %ROM%; sudo perfnorm</command>
+		   <emulators>
+		      <emulator name="retroarch">
+		 	<cores>
+		 	  <core>bluemsx</core>
+		 	  <core>fmsx</core>
+		 	</cores>
+		      </emulator>
+		   </emulators>
+		<platform>msx</platform>
+		<theme>msx2</theme>
+	</system>		
+	<system>
+		<name>zxspectrum</name>
+		<fullname>ZX Spectrum</fullname>
+		<path>/roms/zxspectrum/</path>
+		<extension>.sna .SNA .szx .SZX .z80 .Z80 .tap .TAP .tzx .TZX .gz .GZ .udi .UDI .mgt .MGT .img .IMG .trd .TRD .scl .SCL .dsk .DSK .zip .ZIP .7z .7Z</extension>
+		<command>sudo perfmax; /usr/local/bin/retroarch -L /home/ark/.config/retroarch/cores/fuse_libretro.so %ROM%; sudo perfnorm</command>
+		<platform>zxspectrum</platform>
+		<theme>zxspectrum</theme>
+	</system>	
+	<system>
+		<name>x1</name>
+		<fullname>Sharp - X1</fullname>
+		<path>/roms/x1/</path>
+		<extension>.dx1 .DX1 .zip .ZIP .2d .2D .2hd .2HD .tfd .TFD .d88 .D88 .88d .88D .hdm .HDM .xdf .XDF .dup .DUP .cmd .CMD</extension>
+		<command>sudo perfmax; /usr/local/bin/retroarch -L /home/ark/.config/retroarch/cores/x1_libretro.so %ROM%; sudo perfnorm</command>
+		<platform>x1</platform>
+		<theme>x1</theme>
+	</system>	
+	 <system>
+        <name>x68000</name>
+        <fullname>Sharp - x68000</fullname>
+        <path>/roms/x68000/</path>
+        <extension>.zip .ZIP .2hd .2HD .d88 .D88 .88d .88D .hdm .HDM .hdf .HDF .xdf .XDF .dup .DUP .cmd .CMD .m3u .M3U .img .IMG</extension>
+        <command>sudo perfmax; /usr/local/bin/retroarch -L /home/ark/.config/retroarch/cores/px68k_libretro.so %ROM%; sudo perfnorm</command>
+        <platform>x68000</platform>
+        <theme>x68000</theme>
+    </system>	
+	<system>
+		<name>c64</name>
+		<fullname>Commodore - C64</fullname>
+		<path>/roms/c64/</path>
+		<extension>.d64 .D64 .zip .ZIP .7z .7Z .t64 .T64 .crt .CRT</extension>
+		<command>sudo perfmax; /usr/local/bin/retroarch -L /home/ark/.config/retroarch/cores/vice_x64_libretro.so %ROM%; sudo perfnorm</command>
+		<platform>c64</platform>
+		<theme>c64</theme>
+	</system>	
+	<system>
+		<name>pc98</name>
+		<fullname>NEC - PC98</fullname>
+		<path>/roms/pc98/</path>
+		<extension>.d88 .D88 .hdi .HDI .zip .ZIP</extension>
+		<command>sudo perfmax; /usr/local/bin/retroarch -L /home/ark/.config/retroarch/cores/nekop2_libretro.so %ROM%; sudo perfnorm</command>
+		<platform>pc</platform>
+		<theme>pc98</theme>
+	</system>			
+	<system>
+		<name>pcfx</name>
+		<fullname>NEC - PC-FX</fullname>
+		<path>/roms/pcfx/</path>
+		<extension>.chd .CHD .zip .ZIP .cue .CUE .ccd .CCD .toc .TOC .m3u .M3U</extension>
+		<command>sudo perfmax; /usr/local/bin/retroarch -L /home/ark/.config/retroarch/cores/mednafen_pcfx_libretro.so %ROM%; sudo perfnorm</command>
+		<platform>pcfx</platform>
+		<theme>pcfx</theme>
+	</system>		
+	<system>
+		<name>msdos</name>
+		<fullname>Microsoft - DOS</fullname>
+		<path>/roms/dos/</path>
+		<extension>exe .EXE .com .COM .bat .BAT .conf .CONF .cue .CUE .iso .ISO .m3u .M3U</extension>
+		<command>sudo perfmax; /usr/local/bin/retroarch -L /home/ark/.config/retroarch/cores/dosbox_libretro.so %ROM%; sudo perfnorm</command>
+		<platform>pc</platform>
+		<theme>msdos</theme>
+	</system>	
+    <system>
+		<name>doom</name>
+		<fullname>Doom</fullname>
+		<path>/roms/doom/</path>
+		<extension>.wad .WAD</extension>
+		<command>sudo perfmax; /usr/local/bin/doom.sh %EMULATOR% %CORE% %ROM%; sudo perfnorm</command>
+		   <emulators>
+		      <emulator name="standalone">
+		   </emulator>
+		   <emulator name="retroarch">
+		 	<cores>
+		 	  <core>prboom</core>
+		 	</cores>
+		      </emulator>
+		   </emulators>
+		<platform>doom</platform>
+		<theme>doom</theme>
+	</system>		
+	<system>
+		<name>solarus</name>
+		<fullname>Solarus</fullname>
+		<path>/roms/solarus/</path>
+		<extension>.solarus .SOLARUS .zip .ZIP</extension>
+		<command>sudo perfmax; /usr/local/bin/solarus.sh %ROM%; sudo perfnorm</command>
+		<platform>solarus</platform>
+		<theme>solarus</theme>
+	</system>
+	<system>
+		<name>Ports</name>
+		<fullname>ports</fullname>
+		<path>/roms/ports/</path>
+		<extension>.sh .SH</extension>
+		<command>sudo perfmax; %ROM%; sudo perfnorm</command>
+		<platform>pc</platform>
+		<theme>ports</theme>
+	</system>	
+    <system>
+		<name>scummvm</name>
+		<fullname>SCUMM Virtual Machine</fullname>
+		<path>/roms/scummvm/</path>
+		<extension>.scummvm .SCUMMVM</extension>
+		<command>sudo perfmax; /usr/local/bin/scummvm.sh %EMULATOR% %CORE% %ROM%; sudo perfnorm</command>
+		   <emulators>
+		      <emulator name="retroarch">
+		 	<cores>
+		 	  <core>scummvm</core>
+		 	</cores>
+		      </emulator>
+		      <emulator name="standalone">
+		      </emulator>			  
+		   </emulators>
+	</system>	
+    <system>
+        <name>retropie</name>
+        <fullname>System</fullname>
+        <path>/opt/system/</path>
+        <extension>.sh .SH</extension>
+        <command>sudo chmod 666 /dev/tty1; %ROM% > /dev/tty1; printf "\033c" >> /dev/tty1</command>
+        <platform>cmds</platform>
+        <theme>retropie</theme>
+    </system>
+	<system>
+		<name>Retroarch</name>
+		<fullname>Run command</fullname>
+		<path>/opt/cmds/</path>
+		<extension>.sh .SH</extension>
+		<command>%ROM%</command>
+		<platform>retroarch</platform>
+		<theme>retroarch</theme>
+	</system>
+</systemList>

--- a/Update-RG351P.sh
+++ b/Update-RG351P.sh
@@ -1,7 +1,7 @@
 #!/bin/bash
 clear
 
-UPDATE_DATE="12222020"
+UPDATE_DATE="12252020"
 LOG_FILE="/home/ark/update$UPDATE_DATE.log"
 UPDATE_DONE="/home/ark/.config/.update$UPDATE_DATE"
 
@@ -910,8 +910,7 @@ if [ ! -f "/home/ark/.config/.update12212020-1" ]; then
 	touch "/home/ark/.config/.update12212020-1"
 fi
 
-if [ ! -f "$UPDATE_DONE" ]; then
-
+if [ ! -f "/home/ark/.config/.update12222020" ]; then
 	printf "\nAdd support for half-life\nAdd battery life indicator\nAdd PoP port\nAdd dosbox-pure\nFix solarus exit daemon\n" | tee -a "$LOG_FILE"
 	sudo wget https://github.com/christianhaitian/arkos/raw/main/12222020/arkosupdate12222020.zip -O /home/ark/arkosupdate12222020.zip -a "$LOG_FILE"
 	if [ -f "/home/ark/arkosupdate12222020.zip" ]; then
@@ -935,8 +934,27 @@ if [ ! -f "$UPDATE_DONE" ]; then
 		echo $c_brightness > /sys/devices/platform/backlight/backlight/backlight/brightness
 		exit 1
 	fi
-	
+
+	touch "/home/ark/.config/.update12222020"
+fi
+
+if [ ! -f "$UPDATE_DONE" ]; then
+	sudo cp -v /etc/emulationstation/es_systems.cfg /etc/emulationstation/es_systems.cfg.update12252020.bak | tee -a "$LOG_FILE"
+	sudo wget https://github.com/christianhaitian/arkos/raw/main/12252020/es_systems.cfg -O /etc/emulationstation/es_systems.cfg -a "$LOG_FILE"
+	sudo chmod -v 775 /etc/emulationstation/es_systems.cfg | tee -a "$LOG_FILE"
+	sudo chown -v ark:ark /etc/emulationstation/es_systems.cfg | tee -a "$LOG_FILE"
+
+	if [ -f "/home/ark/.config/.update12225020" ]; then
+	printf "\nUpdate boot text to reflect current version of ArkOS\n" | tee -a "$LOG_FILE"
+		sudo sed -i "/title\=/c\title\=ArkOS 1.5 ($UPDATE_DATE)" /usr/share/plymouth/themes/text.plymouth
+	else
+		printf "\nThe update couldn't complete because the package did not download correctly.\nPlease retry the update again." | tee -a "$LOG_FILE"
+		echo $c_brightness > /sys/devices/platform/backlight/backlight/backlight/brightness
+		exit 1
+	fi
+
 	touch "$UPDATE_DONE"
+
 	rm -v -- "$0" | tee -a "$LOG_FILE"
 	printf "\033c" >> /dev/tty1
 	msgbox "Updates have been completed.  System will now restart after you hit the A button to continue.  If the system doesn't restart after pressing A, just restart the system manually."


### PR DESCRIPTION
Adds .m3u extensions to es_systems.cfg for cores supporting disc control in RetroArch (Amiga, Dreamcast, TGCD, Playstation, Sega CD, etc) and homogenizes extensions for NEC/mednafen_pce systems.