### PR TITLE
Add cloud sync/backup scripts

### DIFF
--- a/10092021/install.sh
+++ b/10092021/install.sh
@@ -1,0 +1,80 @@
+#!/bin/bash
+# arklone cloud sync utility
+# by ridgek
+# Released under GNU GPLv3 license, see LICENSE.md.
+
+printf "\nInstalling cloud sync services\n"
+
+#########
+# ARKLONE
+#########
+git clone --depth 1 https://github.com/ridgekuhn/arklone-arkos /opt/arklone
+
+sudo chown ark:ark /opt/arklone
+chmod u+x /opt/arklone/install.sh
+
+/opt/arklone/install.sh
+
+###########
+# RETROARCH
+###########
+# This prevents arklone path units from being triggered when .zip content is temporarily decompressed by RetroArch
+cp -v "/home/ark/.config/retroarch/retroarch.cfg" "/home/ark/.config/retroarch/retroarch.cfg.arklone.bak"
+cp -v "/home/ark/.config/retroarch32/retroarch.cfg" "/home/ark/.config/retroarch32/retroarch.cfg.arklone.bak"
+
+oldRAstring='cache_directory = ""'
+newRAstring='cache_directory = "/tmp"'
+sed -i "s|${oldRAstring}|${newRAstring}|" /home/ark/.config/retroarch/retroarch.cfg
+sed -i "s|${oldRAstring}|${newRAstring}|" /home/ark/.config/retroarch32/retroarch.cfg
+
+##################
+# EMULATIONSTATION
+##################
+# Modify emulationstation.service
+# This runs emulationstation on tty1 instead of detatched
+cp "/etc/systemd/system/emulationstation.service" "/etc/emulationstation/emulationstation.service.arklone.bak"
+
+sudo bash -c 'cat <<EOF >"/etc/systemd/system/emulationstation.service"
+[Unit]
+Description=ODROID-GO2 EmulationStation
+After=firstboot.service
+
+[Service]
+Type=simple
+User=ark
+WorkingDirectory=/home/ark
+StandardInput=tty
+StandardOutput=journal+console
+StandardError=journal+console
+TTYPath=/dev/tty1
+ExecStart=/usr/bin/emulationstation/emulationstation.sh
+Restart=on-failure
+
+[Install]
+WantedBy=multi-user.target
+
+EOF'
+
+# Modify es_systems.cfg
+# Redirects stdin, stdout, stderr
+# from the tty EmulationStation is attached to (tty1, per above),
+# to the command run from the "Options" menu (/opt/system/ directory)
+cp "/etc/emulationstation/es_systems.cfg" "/etc/emulationstation/es_systems.cfg.arklone.bak"
+
+oldESstring='<command>sudo chmod 666 /dev/tty1; %ROM% > /dev/tty1; printf "\\033c" >> /dev/tty1</command>'
+newESstring='<command>%ROM% \&lt;/dev/tty \&gt;/dev/tty 2\&gt;/dev/tty</command>'
+sudo sed -i "s|${oldESstring}|${newESstring}|" /etc/emulationstation/es_systems.cfg
+
+# Add the arklone settings dialog to EmulationStation "Options" dir
+sudo bash -c 'cat <<EOF >"/opt/system/Cloud Settings.sh"
+#!/bin/bash
+# arklone cloud sync utility
+# by ridgek
+# Released under GNU GPLv3 license, see LICENSE.md.
+
+/opt/arklone/dialogs/scripts/input-listener.sh "/opt/arklone/dialogs/settings.sh"
+EOF'
+
+sudo chown ark:ark "/opt/system/Cloud Settings.sh"
+sudo chmod a+x "/opt/system/Cloud Settings.sh"
+

--- a/10092021/install.sh
+++ b/10092021/install.sh
@@ -72,7 +72,7 @@ sudo bash -c 'cat <<EOF >"/opt/system/Cloud Settings.sh"
 # by ridgek
 # Released under GNU GPLv3 license, see LICENSE.md.
 
-/opt/arklone/dialogs/scripts/input-listener.sh "/opt/arklone/dialogs/settings.sh"
+/opt/arklone/src/dialogs/scripts/input-listener.sh "/opt/arklone/src/dialogs/settings.sh"
 EOF'
 
 sudo chown ark:ark "/opt/system/Cloud Settings.sh"

--- a/10092021/uninstall.sh
+++ b/10092021/uninstall.sh
@@ -1,0 +1,50 @@
+#!/bin/bash
+# arklone cloud sync utility
+# by ridgek
+# Released under GNU GPLv3 license, see LICENSE.md.
+
+printf "\nUninstalling cloud sync services\n"
+
+#########
+# ARKLONE
+#########
+/opt/arklone/uninstall.sh
+
+###########
+# RETROARCH
+###########
+# Restore retroarch.cfgs
+oldRAstring='cache_directory = "/tmp"'
+newRAstring='cache_directory = ""'
+sed -i "s|${oldRAstring}|${newRAstring}|" /home/ark/.config/retroarch/retroarch.cfg
+sed -i "s|${oldRAstring}|${newRAstring}|" /home/ark/.config/retroarch32/retroarch.cfg
+
+##################
+# EMULATIONSTATION
+##################
+# Restore emulationstation.service
+sudo bash -c 'cat <<EOF >"/etc/systemd/system/emulationstation.service"
+[Unit]
+Description=ODROID-GO2 EmulationStation
+After=firstboot.service
+
+[Service]
+Type=simple
+User=ark
+WorkingDirectory=/home/ark
+ExecStart=/usr/bin/emulationstation/emulationstation.sh
+Restart=on-failure
+
+[Install]
+WantedBy=multi-user.target
+
+EOF'
+
+# Restore es_systems.cfg
+oldESstring='<command>%ROM% \&lt;/dev/tty \&gt;/dev/tty 2\&gt;/dev/tty</command>'
+newESstring='<command>sudo chmod 666 /dev/tty1; %ROM% > /dev/tty1; printf "\\033c" >> /dev/tty1</command>'
+sudo sed -i "s|${oldESstring}|${newESstring}|" /etc/emulationstation/es_systems.cfg
+
+# Remove the arklone settings dialog from EmulationStation "Options" dir
+rm -v "/opt/system/Cloud Settings.sh"
+


### PR DESCRIPTION
Closes #37 

"Sometime next weekend" came a week early and I decided to just hammer out a draft tonight. Please note that I wrote this entirely on my desktop machine and haven't tested it on my RG351P at all yet. (Making the unlikely assumption that I didn't make any mistakes, you should be able to just download the 12272020/update.sh script to your device and run it.) Here's what I ended up with:

**Notes:**
* Uses [rclone](https://github.com/rclone/rclone)
    Configuration file is stored at /roms/backup/rclone.conf (and symlinked to the default path, /home/ark/.config/rclone/rclone.conf)
* Exposes one new script to EmulationStation:
    * [/opt/arklone/dialogs/settings.sh]()
    * ~~[/opt/system/Advanced/Backup Settings to Cloud.sh]()~~
* ~~Creates directories:~~
    * ~~/roms/retroarch/saves~~
    * ~~/roms/retroarch/states~~
* ~~Overrides:~~
    * ~~/home/ark/.config/retroarch/retroarch.cfg~~
    * ~~/home/ark/.config/retroarch32/retroarch.cfg~~
    ~~(Both changed so savefiles and savestates are now stored in above directories instead of content directories)~~

**Caveats:**
* ~~Existing ArkOS users will have to manually move their saves from the content dirs to the new paths. rclone uses the same syntax as rsync, and I've had a difficult time in the past while trying to sync saves in content dirs on my local network (ie, targeting specific file extensions in nested subdirectories). If we could figure that syntax out, we could present the user with an option to choose where their saves are stored and sync appropriately. (It would also mean not having to overwrite their retroarch.cfg files on this update!)~~
* The savefile script sends the local directories and then downloads the cloud copy, which is handy for people like myself who use RetroArch on multiple devices. However, this might cause the user to download a bunch of savefiles for games they don't have on their handheld. I don't think we can get around this, but maybe it's not an issue since saveRAM/memcards/etc are relatively small?
* Creating Dropbox API credentials is relatively easy for end-users, but Google Drive (and possibly others) seems pretty difficult bc you can't just generate an OAuth2 token from the Google API dashboard and plug it in. (You have to make a request to the HTTP REST API from rclone or other capable app to receive a usable token.)

**Todos:**
* ~~I forgot to have the update.sh script grant executable permissions to the sync scripts~~
* ~~The retroarch.cfg.bak files included in the update are the stock ArkOS files and should be generated from the user's existing retroarch.cfg files instead.~~
* ~~Make "Sync Savefiles to Cloud.sh" parse retroarch/retroarch.cfg and retroarch32/retroarch.cfg for savefile/savestate dirs~~
* ~~Present select list to user in "Cloud settings.sh" to choose cloud storage string from rclone.conf~~
* ~~Present select list to user in "Backup Settings to Cloud.sh" to choose cloud storage from rclone.conf (Also, I just realized I forgot to implement the selection variable in this script)~~
* ~~Create path units based on retroarch.cfg files~~
* ~~Integrate ArkOS backup script~~
* ~~Integrate changes to emulationstation.service & es_systems.cfg~~
* ~~auto-generate additional path units if sort_savefiles/states_enable = "true" in retroarch.cfg~~
* ~~generate-path-units.sh should automatically enable units if auto-syncing is on~~
* ~~Fix ArkOS backup script crashing~~
* Convert to production update:
    * ~~Rename update lock file to production date and regenerate update payload~~
    * ~~Rename update folder to production date~~
    * Change repo URL in update.sh to production URL
    * Migrate update.sh to Update-RG351P.sh (or merge #101 😉)
* Write documentation for end-users (don't forget to mention paths in retroarch.cfg must be absolute)

@christianhaitian, I've seen `msgbox` and `osk` in your scripts. Is there a similar utility for presenting the user with a couple select-boxes?